### PR TITLE
Chown recursively synced directories (should fix #13)

### DIFF
--- a/lib/vagrant-managed-servers/action/sync_folders.rb
+++ b/lib/vagrant-managed-servers/action/sync_folders.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
             # Create the guest path
             env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
             env[:machine].communicate.sudo(
-              "chown #{ssh_info[:username]} '#{guestpath}'")
+              "chown -R #{ssh_info[:username]} '#{guestpath}'")
 
             # Rsync over to the guest path using the SSH info
             command = [


### PR DESCRIPTION
Also in line with the aws plugin:

https://github.com/mitchellh/vagrant-aws/blob/169ac47e14244a17d13f7d096cfed683a849a2c1/lib/vagrant-aws/action/sync_folders.rb#L73

I think that should fix my issue I had here:

https://github.com/tknerr/vagrant-managed-servers/issues/13
