### PR TITLE
fixing rsync command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 pkg/*
 tags
 Gemfile.lock
+vendor
 
 # Vagrant
 .vagrant

--- a/lib/vagrant-managed-servers/action/sync_folders.rb
+++ b/lib/vagrant-managed-servers/action/sync_folders.rb
@@ -54,13 +54,15 @@ module VagrantPlugins
             # Create the guest path
             env[:machine].communicate.sudo("mkdir -p '#{guestpath}'")
             env[:machine].communicate.sudo(
-              "chown #{ssh_info[:username]} '#{guestpath}'")
+              "chown -R #{ssh_info[:username]} '#{guestpath}'")
 
             # Rsync over to the guest path using the SSH info
+            ssh_key_options = Array(ssh_info[:private_key_path]).map { |path| "-i '#{path}' " }.join
+            ssh_proxy_commands = Array(ssh_info[:proxy_command]).map { |command| "-o ProxyCommand='#{command}' "}.join
             command = [
               "rsync", "--verbose", "--archive", "-z",
-              "--exclude", ".vagrant/",
-              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no -i '#{ssh_info[:private_key_path]}'",
+              "--exclude", ".vagrant/", "--exclude", "Vagrantfile",
+              "-e", "ssh -p #{ssh_info[:port]} -o StrictHostKeyChecking=no #{ssh_key_options} #{ssh_proxy_commands}",
               hostpath,
               "#{ssh_info[:username]}@#{ssh_info[:host]}:#{guestpath}"]
 


### PR DESCRIPTION
Options for ssh_private_key has changed slightly in vagrant 1.4, therefore I think it should be adjusted (like in vagrant-aws)

Second thing is vagrant 1.4.3 added proxy_command to ssh config and therefore its needed in rsync, otherwise it will fail when the managed server is behind hop server
