### PR TITLE
Fixing #19 deprecation warning with vagrant > 1.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,9 @@ group :development do
   # We depend on Vagrant for development, but we don't add it as a
   # gem dependency because we expect to be installed within the
   # Vagrant environment itself using `vagrant plugin`.
-  gem "vagrant",
-    :git => "https://github.com/mitchellh/vagrant.git"
+  gem "vagrant", "1.4.3",
+    :git => "https://github.com/mitchellh/vagrant.git",
+    :ref => "v1.4.3"
   gem "vagrant-berkshelf", "1.4.0.dev1",
     :git => "https://github.com/berkshelf/vagrant-berkshelf.git",
     :ref => "28941db7c2f7d769b979c1d2695ac19b172a6542"


### PR DESCRIPTION
This should fix the deprecation warning for HandleBoxUrl #19 
