### PR TITLE
Pass along the host and guestpath to the translator

### DIFF
--- a/lib/vagrant-managed-servers/action/sync_folders.rb
+++ b/lib/vagrant-managed-servers/action/sync_folders.rb
@@ -35,7 +35,9 @@ module VagrantPlugins
 
             # Windows doesn't support ssh or rsync natively. Use winrm instead
             if (env[:machine].config.vm.communicator == :winrm) then
-              env[:ui].info(I18n.t('vagrant_managed_servers.winrm_upload'))
+              env[:ui].info(I18n.t('vagrant_managed_servers.winrm_upload',
+                                  :hostpath => hostpath,
+                                  :guestpath => guestpath))
               env[:machine].communicate.tap do |comm|
                 comm.upload(hostpath, guestpath)
               end


### PR DESCRIPTION
I forgot to pass along the host and guest path vars to the translator. There's no urgency around merging and releasing this, but I wanted to try to tie up the loose ends before I closed the original ticket. Sorry for the runaround.
