### PR TITLE
Check linked state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ## 0.6.0 (unreleased)
 
 * add missing translation for `vagrant status` ([#35](https://github.com/tknerr/vagrant-managed-servers/issues/35), thanks @warrenseine for reporting!)
+* actually check whether a server is linked before doing any other action (fixes [#34](https://github.com/tknerr/vagrant-managed-servers/issues/34), thanks @warrenseine for reporting!)
 
 ## 0.5.1 (released 2015-02-15)
 

--- a/lib/vagrant-managed-servers/action/is_linked.rb
+++ b/lib/vagrant-managed-servers/action/is_linked.rb
@@ -2,14 +2,15 @@ module VagrantPlugins
   module ManagedServers
     module Action
       # This can be used with "Call" built-in to check if the machine
-      # is created and branch in the middleware.
-      class IsCreated
+      # is linked and branch in the middleware.
+      class IsLinked
         def initialize(app, env)
           @app = app
         end
 
         def call(env)
-          env[:result] = env[:machine].state.id != :not_created
+          puts "woaahhhhh - state.id is #{env[:machine].state.id}"
+          env[:result] = env[:machine].state.id != :not_linked
           @app.call(env)
         end
       end

--- a/lib/vagrant-managed-servers/action/message_already_linked.rb
+++ b/lib/vagrant-managed-servers/action/message_already_linked.rb
@@ -1,15 +1,13 @@
 module VagrantPlugins
   module ManagedServers
     module Action
-      # This can be used with "Call" built-in to check if the machine
-      # is linked and branch in the middleware.
-      class IsLinked
+      class MessageAlreadyLinked
         def initialize(app, env)
           @app = app
         end
 
         def call(env)
-          env[:result] = env[:machine].state.id != :not_linked
+          env[:ui].info(I18n.t("vagrant_managed_servers.states.long_already_linked"))
           @app.call(env)
         end
       end

--- a/lib/vagrant-managed-servers/action/message_not_linked.rb
+++ b/lib/vagrant-managed-servers/action/message_not_linked.rb
@@ -1,15 +1,13 @@
 module VagrantPlugins
   module ManagedServers
     module Action
-      # This can be used with "Call" built-in to check if the machine
-      # is linked and branch in the middleware.
-      class IsLinked
+      class MessageNotLinked
         def initialize(app, env)
           @app = app
         end
 
         def call(env)
-          env[:result] = env[:machine].state.id != :not_linked
+          env[:ui].info(I18n.t("vagrant_managed_servers.states.long_not_linked"))
           @app.call(env)
         end
       end

--- a/lib/vagrant-managed-servers/action/message_not_reachable.rb
+++ b/lib/vagrant-managed-servers/action/message_not_reachable.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         end
 
         def call(env)
-          env[:ui].info(I18n.t("vagrant_managed_servers.host_not_reachable"))
+          env[:ui].info(I18n.t("vagrant_managed_servers.states.long_not_reachable"))
           @app.call(env)
         end
       end

--- a/lib/vagrant-managed-servers/action/read_state.rb
+++ b/lib/vagrant-managed-servers/action/read_state.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
         end
 
         def read_state(machine)
-          return :not_created if machine.id.nil?
+          return :not_linked if machine.id.nil?
 
           ip_address = machine.id
 =begin

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1,7 +1,5 @@
 en:
   vagrant_managed_servers:
-    host_not_reachable: |-
-      The host specified in `config.managed.server` is not reachable.
     warn_networks: |-
       Warning! The ManagedServers provider doesn't support any of the Vagrant
       high-level network configurations (`config.vm.network`). They

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -12,9 +12,9 @@ en:
     winrm_upload: |-
       Uploading with WinRM: %{hostpath} => %{guestpath}
     linking_server: |-
-      Linking vagrant with managed server %{host}
+      Linking with managed server %{host}
     unlinking_server: |-
-      Unlinking vagrant from managed server %{host}
+      Unlinking from managed server %{host}
     rebooting_server: |-
       Rebooting managed server %{host}
     waiting_for_server: |-
@@ -23,7 +23,11 @@ en:
       short_not_linked: |-
         not linked
       long_not_linked: |-
-        The managed server is not "linked" with the vagrant VM yet.
+        The managed server is not linked.
+      short_already_linked: |-
+        already linked
+      long_already_linked: |-
+        The managed server is already linked.
       short_not_reachable: |-
         not reachable
       long_not_reachable: |-

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -20,9 +20,9 @@ en:
     waiting_for_server: |-
       Waiting for %{host} to reboot
     states:
-      short_not_created: |-
+      short_not_linked: |-
         not linked
-      long_not_created: |-
+      long_not_linked: |-
         The managed server is not "linked" with the vagrant VM yet.
       short_not_reachable: |-
         not reachable


### PR DESCRIPTION
With this PR we now actually check whether the managed server is linked or not, i.e.:

 * only provision if linked
 * only ssh / ssh exec if linked
 * do nothing on up if already linked
 * do nothing on destroy if not linked anyway
 * do not reboot if not linked

This brings the plugin actually in line with the README, which ever stated: 
> once "linked", the ssh and provision commands work as expected 

This should also fix #34 