### PR TITLE
Fix network warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * add missing translation for `vagrant status` ([#35](https://github.com/tknerr/vagrant-managed-servers/issues/35), thanks @warrenseine for reporting!)
 * actually check whether a server is linked before doing any other action (fixes [#34](https://github.com/tknerr/vagrant-managed-servers/issues/34), thanks @warrenseine for reporting!)
+* fix the annoying network configuration warning so that it's shown only when necessary ([#37](https://github.com/tknerr/vagrant-managed-servers/pull/37))
 
 ## 0.5.1 (released 2015-02-15)
 

--- a/lib/vagrant-managed-servers/action/warn_networks.rb
+++ b/lib/vagrant-managed-servers/action/warn_networks.rb
@@ -7,11 +7,33 @@ module VagrantPlugins
         end
 
         def call(env)
-          if env[:machine].config.vm.networks.length > 0
+          if custom_networking_defined?(env)
             env[:ui].warn(I18n.t("vagrant_managed_servers.warn_networks"))
           end
 
           @app.call(env)
+        end
+
+        def custom_networking_defined?(env)
+          network_configs = env[:machine].config.vm.networks
+          custom_network_configs = (network_configs - default_network_configs)
+          custom_network_configs.any?
+        end
+
+        #
+        # these are the port forwardings which are always created by default, see:
+        # https://github.com/mitchellh/vagrant/blob/a8dcf92f14/plugins/kernel_v2/config/vm.rb#L393-417
+        #
+        def default_network_configs
+          ssh = [:forwarded_port, {
+            guest: 22,
+            host: 2222,
+            host_ip: "127.0.0.1",
+            id: "ssh",
+            auto_correct: true,
+            protocol: "tcp"
+          }]
+          return [ ssh ]
         end
       end
     end

--- a/lib/vagrant-managed-servers/action/warn_networks.rb
+++ b/lib/vagrant-managed-servers/action/warn_networks.rb
@@ -15,8 +15,9 @@ module VagrantPlugins
         end
 
         def custom_networking_defined?(env)
+          communicator = env[:machine].config.vm.communicator
           network_configs = env[:machine].config.vm.networks
-          custom_network_configs = (network_configs - default_network_configs)
+          custom_network_configs = (network_configs - default_network_configs(communicator))
           custom_network_configs.any?
         end
 
@@ -24,7 +25,23 @@ module VagrantPlugins
         # these are the port forwardings which are always created by default, see:
         # https://github.com/mitchellh/vagrant/blob/a8dcf92f14/plugins/kernel_v2/config/vm.rb#L393-417
         #
-        def default_network_configs
+        def default_network_configs(communicator)
+          winrm = [:forwarded_port, {
+            guest: 5985,
+            host: 55985,
+            host_ip: "127.0.0.1",
+            id: "winrm",
+            auto_correct: true,
+            protocol: "tcp"
+          }]
+          winrm_ssl = [:forwarded_port, {
+            guest: 5986,
+            host: 55986,
+            host_ip: "127.0.0.1",
+            id: "winrm-ssl",
+            auto_correct: true,
+            protocol: "tcp"
+          }]
           ssh = [:forwarded_port, {
             guest: 22,
             host: 2222,
@@ -33,7 +50,11 @@ module VagrantPlugins
             auto_correct: true,
             protocol: "tcp"
           }]
-          return [ ssh ]
+          if communicator == :winrm
+            [ winrm, winrm_ssl ]
+          else
+            [ ssh ]
+          end
         end
       end
     end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2,8 +2,7 @@ en:
   vagrant_managed_servers:
     warn_networks: |-
       Warning! The ManagedServers provider doesn't support any of the Vagrant
-      high-level network configurations (`config.vm.network`). They
-      will be silently ignored.
+      high-level network configurations (`config.vm.network`). They will be ignored.
     rsync_not_found_warning: |-
       Warning! Folder sync disabled because the rsync binary is missing.
       Make sure rsync is installed and the binary can be found in the PATH.


### PR DESCRIPTION
The warning below was *always* shown, no matter if there were actual config.vm.network settings or not:
```
C:\Repos\_github\vagrant-managed-servers>vagrant up my_server
Bringing machine 'my_server' up with 'managed' provider...
==> my_server: Warning! The ManagedServers provider doesn't support any of the Vagrant
==> my_server: high-level network configurations (`config.vm.network`). They
==> my_server: will be silently ignored.
==> my_server: Linking vagrant with managed server 192.168.40.35
==> my_server:  -- Server: 192.168.40.35
```

This was due to the default port forwarding configuration that vagrant creates. 

This PR fixes it by ignoring the implicit default port forwardings and considers only custom made network configuration.