### PR TITLE
update compatibility requirement to 1.6+ (required for winrm/ssh communicators)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ## 0.7.0 (unreleased)
 
 * quote ssh usernames to support active directory style `domain/user` logins ([#38](https://github.com/tknerr/vagrant-managed-servers/issues/38), thanks @chrisbaldauf!)
-* ...
+* document / validate vagrant 1.6+ compatibility which is required for winrm ([#40](https://github.com/tknerr/vagrant-managed-servers/issues/40), thanks @LiamK for reporting!)
 
 ## 0.6.0 (released 2015-03-16)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/tknerr/vagrant-managed-servers.png?branch=master)](https://travis-ci.org/tknerr/vagrant-managed-servers)
 
-This is a [Vagrant](http://www.vagrantup.com) 1.2+ plugin that adds a provider for "managed servers" to Vagrant, i.e. servers for which you have SSH access but no control over their lifecycle.
+This is a [Vagrant](http://www.vagrantup.com) 1.6+ plugin that adds a provider for "managed servers" to Vagrant, i.e. servers for which you have SSH access but no control over their lifecycle.
 
 Since you don't control the lifecycle:
  * `up` and `destroy` are re-interpreted as "linking" / "unlinking" vagrant with a managed server

--- a/lib/vagrant-managed-servers/plugin.rb
+++ b/lib/vagrant-managed-servers/plugin.rb
@@ -6,8 +6,8 @@ end
 
 # This is a sanity check to make sure no one is attempting to install
 # this into an early Vagrant version.
-if Vagrant::VERSION < "1.2.0"
-  raise "The Vagrant ManagedServers plugin is only compatible with Vagrant 1.2+"
+if Vagrant::VERSION < "1.6.0"
+  raise "The Vagrant ManagedServers plugin is only compatible with Vagrant 1.6+"
 end
 
 module VagrantPlugins


### PR DESCRIPTION
The communicators which abstract the ssh/winrm communication were introduced in Vagrant 1.6.

Since we rely on that for winrm support I just updated the compatibiliy requirement (validation in plugin, documentation in README)