### PR TITLE
vagrant-winrm-syncedfolders gemspec dependencies are not loaded as vagrant plugins. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ end
 ```
 
 ### Synced Folders (Windows)
-Vagrant Managed Servers will try several different mechanisms to sync folders for Windows guests. In order of priority:
+It is recommended that you install the `vagrant-winrm-syncedfolders` plugin for communicating with Windows guests (`vagrant plugin install vagrant-winrm-syncedfolders`). Once installed, Vagrant Managed Servers will try several different mechanisms to sync folders for Windows guests. In order of priority:
 
 1. [SMB](http://docs.vagrantup.com/v2/synced-folders/smb.html) - requires running from a Windows host, an Administrative console, and Powershell 3 or greater. Note that there is a known [bug](https://github.com/mitchellh/vagrant/issues/3139) which causes the Powershell version check to hang for Powershell 2
 2. [WinRM](https://github.com/cimpress-mcp/vagrant-winrm-syncedfolders) - uses the WinRM communicator and is reliable, but can be slow for large numbers of files.

--- a/lib/vagrant-managed-servers/action.rb
+++ b/lib/vagrant-managed-servers/action.rb
@@ -62,6 +62,7 @@ module VagrantPlugins
               end
 
               b3.use Provision
+              b3.use WarnWinRMSyncedFolders
               if env[:machine].config.vm.communicator == :winrm
                 # Use the builtin vagrant folder sync for Windows target servers.
                 # This gives us SMB folder sharing, which is much faster than the
@@ -157,6 +158,7 @@ module VagrantPlugins
       autoload :LinkServer, action_root.join("link_server")
       autoload :UnlinkServer, action_root.join("unlink_server")
       autoload :RebootServer, action_root.join("reboot_server")
+      autoload :WarnWinRMSyncedFolders, action_root.join("warn_winrm_syncedfolders")
     end
   end
 end

--- a/lib/vagrant-managed-servers/action/warn_winrm_syncedfolders.rb
+++ b/lib/vagrant-managed-servers/action/warn_winrm_syncedfolders.rb
@@ -1,0 +1,19 @@
+module VagrantPlugins
+  module ManagedServers
+    module Action
+      class WarnWinRMSyncedFolders
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          if env[:machine].config.vm.communicator == :winrm && !Vagrant.has_plugin?("vagrant-winrm-syncedfolders")
+            env[:ui].warn(I18n.t("vagrant_managed_servers.warn_winrm_syncedfolders"))
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -3,6 +3,10 @@ en:
     warn_networks: |-
       Warning! The ManagedServers provider doesn't support any of the Vagrant
       high-level network configurations (`config.vm.network`). They will be ignored.
+    warn_winrm_syncedfolders: |-
+      Warning! The vagrant-winrm-syncedfolders plugin was not found and
+      is recommended for Windows guests. Install it with
+      `vagrant plugin install vagrant-winrm-syncedfolders`.
     rsync_not_found_warning: |-
       Warning! Folder sync disabled because the rsync binary is missing.
       Make sure rsync is installed and the binary can be found in the PATH.

--- a/vagrant-managed-servers.gemspec
+++ b/vagrant-managed-servers.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant-managed-servers"
 
-  s.add_runtime_dependency "vagrant-winrm-syncedfolders"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec-core", "~> 2.14.7"
   s.add_development_dependency "rspec-expectations", "~> 2.14.5"


### PR DESCRIPTION
Add a warning and leave it to the user to install the vagrant-wirnm-syncedfolders plugin.

I think this is a good balance of trying to get the user to do the right thing and making the code less maintainable by forking the implementation. This could easily be changed from a `ui.warn` to a `raise` if we wanted to ensure that the plugin was installed, which I had considered.

If you'd like me to pursue another avenue, that's no problem, just let me know.

Meant to address #49 