### PR TITLE
Add a require statement so that the vagrant-winrm-syncedfolders pluin is loaded

### DIFF
--- a/lib/vagrant-managed-servers.rb
+++ b/lib/vagrant-managed-servers.rb
@@ -1,6 +1,7 @@
 require "pathname"
 
 require "vagrant-managed-servers/plugin"
+require "vagrant-winrm-syncedfolders/plugin"
 
 module VagrantPlugins
   module ManagedServers


### PR DESCRIPTION
This will force the `vagrant-winrm-syncedfolders` plugin to be loaded.

This worked for me when I patched it in locally with the following vagrant plugins:

```
d:\dev\vagrant-managed-servers>vagrant plugin list
vagrant-berkshelf (4.0.4)
vagrant-hostmanager (1.5.0)
vagrant-hostsupdater (0.0.11)
vagrant-librarian-puppet (0.8.0)
vagrant-winrm-syncedfolders (0.1.0)
vagrant-managed-servers (0.7.0)
vagrant-omnibus (1.4.1)
vagrant-puppet-install (2.7.0)
vagrant-share (1.1.3, system)
vagrant-triggers (0.5.0)
vagrant-winrm (0.7.0)
vagrant-winrm-s (0.0.2)
zanzibar (0.1.11)
  - Version Constraint: 0.1.11
```

Relevant snippet from the Vagrantfile
```
    mw_config.vm.synced_folder ".", "/vagrant", type: "winrm"
```

Output
```
d:\dev\vagrant-managed-servers>vagrant provision managed_windows
==> managed_windows: Warning! The ManagedServers provider doesn't support any of
 the Vagrant
==> managed_windows: high-level network configurations (`config.vm.network`). Th
ey will be ignored.
==> managed_windows: Uploading with WinRM: D:/dev/vagrant-managed-servers => /va
grant
```
To address #49