### PR TITLE
Add support for specifying custom SSH port of a managed server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## 0.9.0 (unreleased)
 
-* ...
+* add support for specifying custom SSH port of a managed server
 
 ## 0.8.0 (released 2016-11-04)
 

--- a/lib/vagrant-managed-servers/provider.rb
+++ b/lib/vagrant-managed-servers/provider.rb
@@ -1,5 +1,6 @@
 require "log4r"
 require "vagrant"
+require "uri"
 
 module VagrantPlugins
   module ManagedServers
@@ -19,9 +20,10 @@ module VagrantPlugins
 
       # Returns the SSH info for accessing the managed server.
       def ssh_info
+        uri = URI("ssh://#{@machine.provider_config.server}")
         return {
-          :host => @machine.provider_config.server,
-          :port => 22
+          :host => uri.hostname,
+          :port => uri.port || 22
         }
       end
 


### PR DESCRIPTION
This PR adds support for specifying custom SSH port of a managed server. No new configuration option is added, the port should be specified in the existing `server` configuration option in a standard format, e.g. `192.168.0.1:8022` (for port 8022). It supports IPv6, for example by specifying `server` to be `[::1]:8022`. The presented solution is also backwards compatible.

Solution with configuring `override.ssh` presented in #53 is not optimal when port forwarding is used on a localhost to multiple servers as all of them will share the same internal `id` in Vagrant.

This closes issue #53.